### PR TITLE
Fix for #14  - re-create InputStream before parsing as mp3

### DIFF
--- a/src/processing/sound/SoundFile.java
+++ b/src/processing/sound/SoundFile.java
@@ -56,6 +56,8 @@ public class SoundFile extends AudioSample {
 			} catch (IOException e) {
 				// try parsing as mp3
 				try {
+					// stream as to be re-created, since it was modified in SampleLoader.loadFloatSample()
+					fin = parent.createInput(path);
 					Sound mp3 = new Sound(fin);
 					try {
 						ByteArrayOutputStream os = new ByteArrayOutputStream();


### PR DESCRIPTION
When trying to load a file as wav/aif, the input stream is modified (4 byte header is read).
Using this modified stream can result in wrong parsing of the mp3 header, which results int the exception described in issue #14 .