### PR TITLE
Don't cause ArrayIndexOutOfBoundsException in some examples on Android.

### DIFF
--- a/examples/Noise/NoiseSpectrum/NoiseSpectrum.pde
+++ b/examples/Noise/NoiseSpectrum/NoiseSpectrum.pde
@@ -34,7 +34,7 @@ void setup() {
 
 void draw() {
   // Only play one of the four oscillators, based on mouseY
-  int nextNoise = floor(map(mouseY, 0, height, 0, noises.length));
+  int nextNoise = constrain(floor(map(mouseY, 0, height, 0, noises.length)), 0, noises.length - 1);
 
   if (nextNoise != current) {
     noises[current].stop();

--- a/examples/Oscillators/OscillatorSpectrum/OscillatorSpectrum.pde
+++ b/examples/Oscillators/OscillatorSpectrum/OscillatorSpectrum.pde
@@ -40,7 +40,7 @@ void setup() {
 
 void draw() {
   // Only play one of the four oscillators, based on mouseY
-  int nextOscillator = floor(map(mouseY, 0, height, 0, oscs.length));
+  int nextOscillator = constrain(floor(map(mouseY, 0, height, 0, oscs.length)), 0, oscs.length - 1);
 
   if (nextOscillator != current) {
     oscs[current].stop();


### PR DESCRIPTION
On Android, the mouse position can be outside the sketch bounds because Processing detects touch events for the entire screen, not just the sketch. This causes ArrayIndexOutOfBoundsException for the spectrum examples (NoiseSpectrum and OscillatorSpectrum), so added an extra check to prevent out of bounds access.