### PR TITLE
Improve Android audio input permission not granted error message

### DIFF
--- a/src/processing/sound/AndroidPermissionException.java
+++ b/src/processing/sound/AndroidPermissionException.java
@@ -1,0 +1,11 @@
+package processing.sound;
+
+/**
+ * AndroidPermissionException is thrown when trying to create an AudioIn on
+ * Android when you have not granted the required RECORD_AUDIO permission.
+ */
+public class AndroidPermissionException extends RuntimeException {
+	public AndroidPermissionException(String message) {
+		super(message);
+	}
+}

--- a/src/processing/sound/AudioIn.java
+++ b/src/processing/sound/AudioIn.java
@@ -26,8 +26,6 @@ public class AudioIn extends SoundObject {
 		"your sketch initialization code (the Sound library's\n" +
 		"AudioInputAndroid example demonstrates how to do both)\n";
 
-	private boolean permissionGranted;
-
 	public AudioIn(PApplet parent) {
 		this(parent, 0);
 	}
@@ -41,50 +39,36 @@ public class AudioIn extends SoundObject {
 	public AudioIn(PApplet parent, int in) {
 		super(parent);
 
-		permissionGranted = true;
-
 		if (Engine.getAudioManager() instanceof JSynAndroidAudioDeviceManager) {
 			// we're on Android, check if the sketch has permission to capture Audio
 			if (!parent.hasPermission(Manifest.permission.RECORD_AUDIO)) {
-				Engine.printWarning(ANDROID_PERMISSION_WARNING_MESSAGE);
-				permissionGranted = false;
+			    throw new AndroidPermissionException(ANDROID_PERMISSION_WARNING_MESSAGE);
 			}
 		}
 
-		if (permissionGranted) {
-			this.input = new ChannelIn(in);
-			this.multiplier = new Multiply();
-			this.multiplier.inputA.connect(this.input.output);
-			this.amplitude = this.multiplier.inputB;
-			// set default amplitude
-			this.multiplier.inputB.set(1.0);
+		this.input = new ChannelIn(in);
+		this.multiplier = new Multiply();
+		this.multiplier.inputA.connect(this.input.output);
+		this.amplitude = this.multiplier.inputB;
+		// set default amplitude
+		this.multiplier.inputB.set(1.0);
 
-			this.circuit = new JSynCircuit(this.multiplier.output);
-			this.circuit.add(this.input);
-		} else {
-			// What to do here?
-			// Need some type of dummy microphone
-		}
+		this.circuit = new JSynCircuit(this.multiplier.output);
+		this.circuit.add(this.input);
 	}
 
 	public void play() {
-		if (permissionGranted) {
-			super.play();
-		}
+		super.play();
 	}
 
 	public void play(float amp) {
-		if (permissionGranted) {
-			this.amp(amp);
-			this.play();
-		}
+		this.amp(amp);
+		this.play();
 	}
 
 	public void play(float amp, float add) {
-		if (permissionGranted) {
-			this.add(add);
-			this.play(amp);
-		}
+		this.add(add);
+		this.play(amp);
 	}
 
 	/**
@@ -101,30 +85,22 @@ public class AudioIn extends SoundObject {
 	 * @webref sound
 	 **/
 	public void play(float amp, float add, float pos) {
-		if (permissionGranted) {
-			this.set(amp, add, pos);
-			this.play();
-		}
+		this.set(amp, add, pos);
+		this.play();
 	}
 
 	public void start() {
-		if (permissionGranted) {
-			Engine.getEngine().add(this.circuit);
-		}
+		Engine.getEngine().add(this.circuit);
 	}
 
 	public void start(float amp) {
-		if (permissionGranted) {
-			this.amp(amp);
-			this.start();
-		}
+		this.amp(amp);
+		this.start();
 	}
 
 	public void start(float amp, float add) {
-		if (permissionGranted) {
-			this.add(add);
-			this.start(amp);
-		}
+		this.add(add);
+		this.start(amp);
 	}
 
 	/**
@@ -142,10 +118,8 @@ public class AudioIn extends SoundObject {
 	 * @webref sound
 	 */
 	public void start(float amp, float add, float pos) {
-		if (permissionGranted) {
-			this.set(amp, add, pos);
-			this.start();
-		}
+		this.set(amp, add, pos);
+		this.start();
 	}
 
 	/**
@@ -162,10 +136,8 @@ public class AudioIn extends SoundObject {
 	 *            between -1.0 (left) and 1.0 (right)
 	 **/
 	public void set(float amp, float add, float pos) {
-		if (permissionGranted) {
-			this.amp(amp);
-			this.add(add);
-			this.pan(pos);
-		}
+		this.amp(amp);
+		this.add(add);
+		this.pan(pos);
 	}
 }

--- a/src/processing/sound/AudioIn.java
+++ b/src/processing/sound/AudioIn.java
@@ -20,6 +20,14 @@ public class AudioIn extends SoundObject {
 	// port, so we need to control the amplitude via an extra multiplier unit
 	private Multiply multiplier;
 
+	private String ANDROID_PERMISSION_WARNING_MESSAGE =
+		"sketch does not have permission to record audio from microphone,\n" +
+		"please request the permission in your AndroidManifest.xml and in\n" +
+		"your sketch initialization code (the Sound library's\n" +
+		"AudioInputAndroid example demonstrates how to do both)\n";
+
+	private boolean permissionGranted;
+
 	public AudioIn(PApplet parent) {
 		this(parent, 0);
 	}
@@ -32,40 +40,51 @@ public class AudioIn extends SoundObject {
 	 */
 	public AudioIn(PApplet parent, int in) {
 		super(parent);
+
+		permissionGranted = true;
+
 		if (Engine.getAudioManager() instanceof JSynAndroidAudioDeviceManager) {
 			// we're on Android, check if the sketch has permission to capture Audio
 			if (!parent.hasPermission(Manifest.permission.RECORD_AUDIO)) {
-//			if (ContextCompat.checkSelfPermission(parent.getContext(), Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_DENIED) {
-				Engine.printWarning("sketch does not have permission to record audio from microphone, please request the permission in your AndroidManifest.xml or in your sketch initialization code (the Sound library's AudioInputAndroid example demonstrates how to do both)");
-				// requesting permission in here is problematic because the
-				// user dialogue and granting of permission are asynchronous
-//				ActivityCompat.requestPermissions(parent.getContext(), new String[]{ Manifest.permission.RECORD_AUDIO }, -1);
-//				parent.requestPermission("android.permission.RECORD_AUDIO", "notObviousHowThisApproachCouldBeUsed");
+				Engine.printWarning(ANDROID_PERMISSION_WARNING_MESSAGE);
+				permissionGranted = false;
 			}
 		}
-		this.input = new ChannelIn(in);
-		this.multiplier = new Multiply();
-		this.multiplier.inputA.connect(this.input.output);
-		this.amplitude = this.multiplier.inputB;
-		// set default amplitude
-		this.multiplier.inputB.set(1.0);
 
-		this.circuit = new JSynCircuit(this.multiplier.output);
-		this.circuit.add(this.input);
+		if (permissionGranted) {
+			this.input = new ChannelIn(in);
+			this.multiplier = new Multiply();
+			this.multiplier.inputA.connect(this.input.output);
+			this.amplitude = this.multiplier.inputB;
+			// set default amplitude
+			this.multiplier.inputB.set(1.0);
+
+			this.circuit = new JSynCircuit(this.multiplier.output);
+			this.circuit.add(this.input);
+		} else {
+			// What to do here?
+			// Need some type of dummy microphone
+		}
 	}
 
 	public void play() {
-		super.play();
+		if (permissionGranted) {
+			super.play();
+		}
 	}
 
 	public void play(float amp) {
-		this.amp(amp);
-		this.play();
+		if (permissionGranted) {
+			this.amp(amp);
+			this.play();
+		}
 	}
 
 	public void play(float amp, float add) {
-		this.add(add);
-		this.play(amp);
+		if (permissionGranted) {
+			this.add(add);
+			this.play(amp);
+		}
 	}
 
 	/**
@@ -82,22 +101,30 @@ public class AudioIn extends SoundObject {
 	 * @webref sound
 	 **/
 	public void play(float amp, float add, float pos) {
-		this.set(amp, add, pos);
-		this.play();
+		if (permissionGranted) {
+			this.set(amp, add, pos);
+			this.play();
+		}
 	}
 
 	public void start() {
-		Engine.getEngine().add(this.circuit);
+		if (permissionGranted) {
+			Engine.getEngine().add(this.circuit);
+		}
 	}
 
 	public void start(float amp) {
-		this.amp(amp);
-		this.start();
+		if (permissionGranted) {
+			this.amp(amp);
+			this.start();
+		}
 	}
 
 	public void start(float amp, float add) {
-		this.add(add);
-		this.start(amp);
+		if (permissionGranted) {
+			this.add(add);
+			this.start(amp);
+		}
 	}
 
 	/**
@@ -115,8 +142,10 @@ public class AudioIn extends SoundObject {
 	 * @webref sound
 	 */
 	public void start(float amp, float add, float pos) {
-		this.set(amp, add, pos);
-		this.start();
+		if (permissionGranted) {
+			this.set(amp, add, pos);
+			this.start();
+		}
 	}
 
 	/**
@@ -133,8 +162,10 @@ public class AudioIn extends SoundObject {
 	 *            between -1.0 (left) and 1.0 (right)
 	 **/
 	public void set(float amp, float add, float pos) {
-		this.amp(amp);
-		this.add(add);
-		this.pan(pos);
+		if (permissionGranted) {
+			this.amp(amp);
+			this.add(add);
+			this.pan(pos);
+		}
 	}
 }

--- a/src/processing/sound/AudioIn.java
+++ b/src/processing/sound/AudioIn.java
@@ -21,7 +21,7 @@ public class AudioIn extends SoundObject {
 	private Multiply multiplier;
 
 	private String ANDROID_PERMISSION_WARNING_MESSAGE =
-		"sketch does not have permission to record audio from microphone,\n" +
+		"\nsketch does not have permission to record audio from microphone,\n" +
 		"please request the permission in your AndroidManifest.xml and in\n" +
 		"your sketch initialization code (the Sound library's\n" +
 		"AudioInputAndroid example demonstrates how to do both)\n";
@@ -42,7 +42,8 @@ public class AudioIn extends SoundObject {
 		if (Engine.getAudioManager() instanceof JSynAndroidAudioDeviceManager) {
 			// we're on Android, check if the sketch has permission to capture Audio
 			if (!parent.hasPermission(Manifest.permission.RECORD_AUDIO)) {
-			    throw new AndroidPermissionException(ANDROID_PERMISSION_WARNING_MESSAGE);
+				Engine.printWarning(ANDROID_PERMISSION_WARNING_MESSAGE);
+				throw new AndroidPermissionException("RECORD_AUDIO permission not granted");
 			}
 		}
 

--- a/src/processing/sound/JSynAndroidAudioDeviceManager.java
+++ b/src/processing/sound/JSynAndroidAudioDeviceManager.java
@@ -119,8 +119,10 @@ class JSynAndroidAudioDeviceManager implements AudioDeviceManager {
 		}
 
 		public void stop() {
-			this.audioTrack.stop();
-			this.audioTrack.release();
+			if (this.audioTrack != null) {
+				this.audioTrack.stop();
+				this.audioTrack.release();
+			}
 		}
 
 		public void close() {
@@ -189,8 +191,10 @@ class JSynAndroidAudioDeviceManager implements AudioDeviceManager {
 		}
 
 		public void stop() {
-			this.audioRecord.stop();
-			this.audioRecord.release();
+			if (this.audioRecord != null) {
+				this.audioRecord.stop();
+				this.audioRecord.release();
+			}
 		}
 
 		public int available() {


### PR DESCRIPTION
We throw an exception when the permission is not granted because this exception is a lot easier for the user to understand than the exception thrown otherwise.

Tested on my phone from Android mode on Windows and also from APDE.