### PR TITLE
Changing comments to fit with the new reference system

### DIFF
--- a/src/processing/sound/Amplitude.java
+++ b/src/processing/sound/Amplitude.java
@@ -9,7 +9,8 @@ import processing.core.PApplet;
  * This is a volume analyzer. It calculates the root mean square of the
  * amplitude of each audio block and returns that value.
  * 
- * @webref sound
+ * @webref analysis
+ * @webBrief This is a volume analyzer.
  */
 public class Amplitude extends Analyzer {
 
@@ -39,7 +40,8 @@ public class Amplitude extends Analyzer {
 	/**
 	 * Queries a value from the analyzer and returns a float between 0. and 1.
 	 * 
-	 * @webref sound
+	 * @webref amplitude
+	 * @webBrief Queries a value from the analyzer and returns a float between 0. and 1.
 	 * @return amp An amplitude value between 0-1.
 	 **/
 	public float analyze() {
@@ -57,7 +59,8 @@ public class Amplitude extends Analyzer {
 	 * @param input
 	 *            the input sound source. Can be an oscillator, noise generator,
 	 *            SoundFile or AudioIn.
-	 * @webref sound
+	 * @webref amplitude
+	 * @webBrief Define the audio input for the analyzer.
 	 **/
 	public void input(SoundObject input) {
 		super.input(input);

--- a/src/processing/sound/AudioIn.java
+++ b/src/processing/sound/AudioIn.java
@@ -9,7 +9,8 @@ import processing.core.PApplet;
 /**
  * AudioIn lets you grab the audio input from your sound card.
  * 
- * @webref sound
+ * @webref I/O
+ * @webBrief AudioIn lets you grab the audio input from your sound card.
  **/
 public class AudioIn extends SoundObject {
 
@@ -92,7 +93,8 @@ public class AudioIn extends SoundObject {
 	 * @param pos
 	 *            pan the audio input in a stereo panorama. Allowed values are
 	 *            between -1.0 (left) and 1.0 (right)
-	 * @webref sound
+	 * @webref audioin
+	 * @webBrief Start capturing the input stream and route it to the audio output
 	 **/
 	public void play(float amp, float add, float pos) {
 		this.set(amp, add, pos);
@@ -125,7 +127,8 @@ public class AudioIn extends SoundObject {
 	 * @param pos
 	 *            pan the audio input in a stereo panorama. Allowed values are
 	 *            between -1.0 (left) and 1.0 (right)
-	 * @webref sound
+	 * @webref audioin
+	 * @webBrief Start the input stream without routing it to the audio output. 
 	 */
 	public void start(float amp, float add, float pos) {
 		this.set(amp, add, pos);
@@ -135,7 +138,8 @@ public class AudioIn extends SoundObject {
 	/**
 	 * Sets amplitude, add and pan position with one method.
 	 * 
-	 * @webref sound
+	 * @webref audioin
+	 * @webBrief Sets amplitude, add and pan position with one method.
 	 * @param amp
 	 *            the volume to grab the input at as a value from 0.0 (complete
 	 *            silence) to 1.0 (full volume)

--- a/src/processing/sound/AudioSample.java
+++ b/src/processing/sound/AudioSample.java
@@ -14,7 +14,9 @@ import processing.core.PApplet;
  * If you want to pre-load your audio sample with an audio file from disk you
  * can do so using the SoundFile subclass.
  * 
- * @webref sound
+ * @webref sampling
+ * @webBrief This class allows you low-level access to an audio buffer to create, access,
+ * manipulate and play back sound samples.
  */
 public class AudioSample extends SoundObject {
 
@@ -51,7 +53,8 @@ public class AudioSample extends SoundObject {
 	 * @param stereo
 	 *            whether to treat the audiosample as 2-channel (stereo) or not
 	 *            (default: false)
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Allocate a new audiosample buffer with the given number of frames.
 	 */
 	public AudioSample(PApplet parent, int frames, boolean stereo, int frameRate) {
 		super(parent);
@@ -73,7 +76,6 @@ public class AudioSample extends SoundObject {
 	 *            an array of float values to be used as this audiosample's sound
 	 *            data. The audiosample will consequently have as many frames as the
 	 *            length of the given array.
-	 * @webref sound
 	 */
 	public AudioSample(PApplet parent, float[] data) {
 		this(parent, data, false);
@@ -155,12 +157,13 @@ public class AudioSample extends SoundObject {
 	}
 
 	/**
-	 * Change the amplitude/volume of this audiosample.
+	 * Change the amplitude/volume of the player. Values are between 0.0 and 1.0.
 	 *
 	 * @param amp
 	 *            A float value between 0.0 (complete silence) and 1.0 (full volume)
 	 *            controlling the amplitude/volume of this sound.
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Changes the amplitude/volume of the player.
 	 **/
 	public void amp(float amp) {
 		if (Engine.checkAmp(amp)) {
@@ -169,22 +172,24 @@ public class AudioSample extends SoundObject {
 	}
 
 	/**
-	 * Returns the number of channels in the audiosample.
+	 * Returns the number of channels in the audiosample as an int (1 for mono, 2 for stereo).
 	 * 
 	 * @return the number of channels in the audiosample (1 for mono, 2 for stereo)
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Returns the number of channels in the audiosample as an int (1 for mono, 2 for stereo).
 	 **/
 	public int channels() {
 		return this.sample.getChannelsPerFrame();
 	}
 
 	/**
-	 * Cues the playhead to a fixed position in the audiosample.
+	 * Cues the playhead to a fixed position in the audiosample. Note that <b>cue()</b> only affects the playhead for future calls to <b>play()</b>, but not to <b>loop()</b>.
 	 * 
 	 * @param time
 	 *            position in the audiosample that the next playback should start
 	 *            from, in seconds.
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Cues the playhead to a fixed position in the audiosample.
 	 **/
 	public void cue(float time) {
 		if (this.setStartTime(time)) {
@@ -196,7 +201,8 @@ public class AudioSample extends SoundObject {
 	/**
 	 * Cues the playhead to a fixed position in the audiosample.
 	 * 
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Cues the playhead to a fixed position in the audiosample.
 	 * @param frameNumber
 	 *            frame number to start playback from.
 	 **/
@@ -210,7 +216,8 @@ public class AudioSample extends SoundObject {
 	/**
 	 * Returns the duration of the audiosample in seconds.
 	 * 
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Returns the duration of the audiosample in seconds.
 	 * @return The duration of the audiosample in seconds.
 	 **/
 	public float duration() {
@@ -218,9 +225,10 @@ public class AudioSample extends SoundObject {
 	}
 
 	/**
-	 * Returns the number of frames of the audiosample.
+	 * Returns the number of frames of the audiosample as an int.
 	 * 
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Returns the number of frames of the audiosample as an int.
 	 * @return The number of frames of the audiosample.
 	 **/
 	public int frames() {
@@ -256,13 +264,14 @@ public class AudioSample extends SoundObject {
 	}
 
 	/**
-	 * Jump to a specific position in the audiosample without interrupting playback.
+	 * Jump to a specific position in the audiosample while continuing to play (or starting to play if it wasn't playing already).
 	 * 
 	 * @param time
 	 *            position to jump to, in seconds.
 	 * @see cue
 	 * @see play
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Jump to a specific position in the audiosample while continuing to play (or starting to play if it wasn't playing already).
 	 **/
 	public void jump(float time) {
 		// FIXME this currently only works for simply *playing* files, if the
@@ -283,6 +292,7 @@ public class AudioSample extends SoundObject {
 	 * @see cue
 	 * @see play
 	 * @webref sound
+	 * @webBrief Jump to a specific position in the audiosample without interrupting playback.
 	 **/
 	public void jumpFrame(int frameNumber) {
 		if (this.setStartFrame(frameNumber)) {
@@ -356,7 +366,8 @@ public class AudioSample extends SoundObject {
 	}
 
 	/**
-	 * Starts playback which loops from the beginning to the end of the sample.
+	 * Starts the playback of the audiosample. Only plays to the end of the audiosample 
+	 * once. If <b>cue()</b> or <b>pause()</b> were called previously, playback will resume from the cued position.
 	 * 
 	 * @param rate
 	 *            relative playback rate to use. 1 is the original speed. 0.5 is
@@ -370,7 +381,8 @@ public class AudioSample extends SoundObject {
 	 *            0.0 (complete silence) to 1.0 (full volume)
 	 * @param add
 	 *            offset the output of the generator by the given value
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Starts the playback of the audiosample.
 	 **/
 	public void loop(float rate, float pos, float amp, float add) {
 		this.add(add);
@@ -450,8 +462,8 @@ public class AudioSample extends SoundObject {
 	}
 
 	/**
-	 * Starts the playback of the audiosample. Only plays to the end of the
-	 * audiosample once.
+	 * Starts the playback of the audiosample. Only plays to the end of the audiosample 
+	 * once. If <b>cue()</b> or <b>pause()</b> were called previously, playback will resume from the cued position.
 	 * 
 	 * @param rate
 	 *            relative playback rate to use. 1 is the original speed. 0.5 is
@@ -468,7 +480,8 @@ public class AudioSample extends SoundObject {
 	 *            seconds.
 	 * @param add
 	 *            offset the output of the generator by the given value
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Starts the playback of the audiosample.
 	 **/
 	public void play(float rate, float pos, float amp, float add, float cue) {
 		this.cue(cue);
@@ -497,6 +510,8 @@ public class AudioSample extends SoundObject {
 	 *            position in the audiosample that playback should start from, in
 	 *            seconds.
 	 * @webref sound
+	 * @webBrief Starts the playback of the audiosample for the specified duration or to the
+	 * end of the audiosample, whichever comes first.
 	 **/
 	public void playFor(float duration, float cue) {
 		this.cue(cue);
@@ -504,13 +519,15 @@ public class AudioSample extends SoundObject {
 	}
 
 	/**
-	 * Set the playback rate of the audiosample.
+	 * Set the relative playback rate of the audiosample. 1 is the original speed. 
+	 * 0.5 is half speed and one octave down. 2 is double the speed and one octave up.
 	 * 
 	 * @param rate
 	 *            Relative playback rate to use. 1 is the original speed. 0.5 is
 	 *            half speed and one octave down. 2 is double the speed and one
 	 *            octave up.
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Set the relative playback rate of the audiosample.
 	 **/
 	public void rate(float rate) {
 		if (rate <= 0) {
@@ -522,15 +539,17 @@ public class AudioSample extends SoundObject {
 	}
 
 	/**
-	 * Resizes the underlying buffer of the audiosample to the given number of
-	 * frames.
+	 * Resizes the underlying buffer of the audiosample to the given number of frames. 
+	 * Calling this method allocates a completely new buffer, so any ongoing playback 
+	 * will be stopped and all data currently stored in the sample will be lost.
 	 * 
 	 * @param frames
 	 *            the desired number of frames for this audiosample
 	 * @param stereo
 	 *            whether to treat the audiosample as 2-channel (stereo) or not
 	 *            (default: false)
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Resizes the underlying buffer of the audiosample to the given number of frames.
 	 */
 	public void resize(int frames, boolean stereo) {
 		this.stop();
@@ -541,7 +560,8 @@ public class AudioSample extends SoundObject {
 	/**
 	 * Returns the underlying sample rate of the audiosample.
 	 * 
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Returns the underlying sample rate of the audiosample.
 	 * @return Returns the underlying sample rate of the audiosample as an int.
 	 **/
 	public int sampleRate() {
@@ -549,9 +569,11 @@ public class AudioSample extends SoundObject {
 	}
 
 	/**
-	 * Move the sound in a stereo panorama. Only works for mono audiosamples!
+	 * Pan the soundfile in a stereo panorama. -1.0 pans to the left channel and 1.0 to the right channel. 
+	 * Note that panning is only supported for mono (1 channel) audiosamples.
 	 *
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Pan the soundfile in a stereo panorama.
 	 * @param pos
 	 *            the panoramic position of this sound unit from -1.0 (left) to 1.0
 	 *            (right).
@@ -561,9 +583,10 @@ public class AudioSample extends SoundObject {
 	}
 
 	/**
-	 * Set multiple parameters at once
+	 * Set multiple parameters at once.
 	 * 
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Set multiple parameters at once.
 	 * @param rate
 	 *            Relative playback rate to use. 1 is the original speed. 0.5 is
 	 *            half speed and one octave down. 2 is double the speed and one
@@ -587,7 +610,8 @@ public class AudioSample extends SoundObject {
 	/**
 	 * Stops the playback.
 	 * 
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Stops the playback.
 	 **/
 	public void stop() {
 		this.player.dataQueue.clear();
@@ -605,7 +629,8 @@ public class AudioSample extends SoundObject {
 	 * not necessarily the last one that was triggered.
 	 * 
 	 * @return The current position of the audio sample playback in seconds
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Get current sound file playback position in seconds.
 	 */
 	public float position() {
 		return this.positionFrame() / (float) this.sampleRate();
@@ -615,12 +640,13 @@ public class AudioSample extends SoundObject {
 	 * Get frame index of current sound file playback position.
 	 * 
 	 * Note that, if this audio sample was at some point played back in parallel
-	 * (triggered by another call to play() before the original playback had finished),
+	 * (triggered by another call to <b>play()</b> before the original playback had finished),
 	 * the position returned by this function can be of any of the concurrent playbacks,
 	 * not necessarily the last one that was triggered.
 	 * 
 	 * @return The current frame index position of the audio sample playback
 	 * @webref sound
+	 * @webBrief Get frame index of current sound file playback position.
 	 */
 	public int positionFrame() {
 		return (int) (this.startFrame + this.player.dataQueue.getFrameCount() - this.startFrameCountOffset) % this.frames();
@@ -629,23 +655,26 @@ public class AudioSample extends SoundObject {
 	 * Get current sound file playback position in percent.
 	 * 
 	 * Note that, if this audio sample was at some point played back in parallel
-	 * (triggered by another call to play() before the original playback had finished),
+	 * (triggered by another call to <b>play()</b> before the original playback had finished),
 	 * the position returned by this function can be of any of the concurrent playbacks,
 	 * not necessarily the last one that was triggered.
 	 * 
 	 * @return The current position of the audio sample playback in percent (a value
 	 *         between 0 and 100).
 	 * @webref sound
+	 * @webBrief Get current sound file playback position in percent.
 	 */
 	public float percent() {
 		return 100f * this.positionFrame() / (float) this.frames();
 	}
 
 	/**
-	 * Stop the playback of the sample, but cue it to the current position.
+	 * Stop the playback of the sample, but cue it to the current position. 
+	 * The next call to <b>play()</b> will continue playing where it left off.
 	 * 
 	 * @see cue
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief Stop the playback of the sample, but cue it to the current position.
 	 */
 	public void pause() {
 		if (this.isPlaying()) {
@@ -696,8 +725,15 @@ public class AudioSample extends SoundObject {
 	}
 
 	/**
-	 * Read some frames of this audio sample into an array. Stereo samples
-	 * contain two data points per frame.
+	 * The underlying data of the audiosample can be read and written in several different ways:
+	 * the method taking a single float array `data` gets the current sample data and write it 
+	 * into the given array. The array has to be able to store as many floats as there are frames 
+	 * in this sample.
+	 * It is also possible to only read parts of the sample data using the method with four arguments, 
+	 * which allows you to specify the index of the first frame to read, the position in the array to 
+	 * write it to, as well as how many frames to copy over into the array in total.
+	 * Finally, the method taking a single integer argument `index` returns the value of the single 
+	 * audio frame of the sample at this index as a float.
 	 *
 	 * @param startFrame
 	 *            the index of the first frame of the audiosample that should be
@@ -708,7 +744,8 @@ public class AudioSample extends SoundObject {
 	 * @param numFrames
 	 *            the number of frames that should be read (can't be greater than
 	 *            audiosample.channels() * data.length - startIndex)
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief The underlying data of the audiosample can be read and written in several different.
 	 */
 	public void read(int startFrame, float[] data, int startIndex, int numFrames) {
 		if (this.checkStartFrame(startFrame)) {
@@ -735,7 +772,6 @@ public class AudioSample extends SoundObject {
 	 *            right channel in interleaved order. (See the Soundfile > StereoSample
 	 *            example for a demonstration.)
 	 * @return float: the value of the audio sample at the given index
-	 * @webref sound
 	 */
 	public float read(int frameIndex) {
 		// TODO catch exception and print understandable error message
@@ -747,7 +783,6 @@ public class AudioSample extends SoundObject {
 	 *            the channel from which to extract the frame value (0 for left,
 	 *            1 for right). `read(frameIndex, channelIndex)` is the same as
 	 *            calling `read(frameIndex * this.channels() + channelIndex)`.
-	 * @webref sound
          */
 	public float read(int frameIndex, int channelIndex) {
 		if (channelIndex < 0 || channelIndex >= this.channels()) {
@@ -778,8 +813,14 @@ public class AudioSample extends SoundObject {
 	}
 
 	/**
-	 * Write some frames of this audio sample. Stereo samples require two data
-	 *.points per frame.
+	 * The underlying data of the audiosample can be read and (over)written in several different ways:
+	 * the method taking a single float array `data` replaces the sample data with the content of the 
+	 * given array. The array has to contain as many floats as there are frames in this sample.
+	 * It is also possible to only write parts of the sample data using the method with four arguments, 
+	 * which allows you to specify the index of the first frame to write, the position in the array to 
+	 * take the data from, as well as how many frames should be copied over.
+	 * Finally, the method taking two arguments simply sets the value of the single audio frame 
+	 * specified by the first argument to the given float value.
 	 *
 	 * @param startFrame
 	 *            the index of the first frame of the audiosample that should be
@@ -790,7 +831,8 @@ public class AudioSample extends SoundObject {
 	 * @param numFrames
 	 *            the number of frames that should be written (can't be greater than
 	 *            audiosample.channels() * data.length - startIndex)
-	 * @webref sound
+	 * @webref audiosample
+	 * @webBrief The underlying data of the audiosample can be read and (over)written in several different ways.
 	 */
 	public void write(int startFrame, float[] data, int startIndex, int numFrames) {
 		// FIXME check stereo case

--- a/src/processing/sound/BandPass.java
+++ b/src/processing/sound/BandPass.java
@@ -6,7 +6,8 @@ import processing.core.PApplet;
 
 /**
  * This is a band pass filter.
- * @webref sound
+ * @webref effects
+ * @webBrief This is a band pass filter.
  * @param parent PApplet: typically use "this"
  **/
 public class BandPass extends Effect<FilterBandPass> {
@@ -22,7 +23,8 @@ public class BandPass extends Effect<FilterBandPass> {
 
 	/**
 	 * Set the bandwidth for the filter.
-	 * @webref sound
+	 * @webref bandpass
+	 * @webBrief Set the bandwidth for the filter.
 	 * @param freq Bandwidth in Hz
 	 **/
 	public void bw(float bw) {
@@ -32,15 +34,16 @@ public class BandPass extends Effect<FilterBandPass> {
 	}
 
 	/**
-	 * Set the cutoff frequency for the filter 
-	 * @webref sound
+	 * Set the cutoff frequency for the filter.
+	 * @webref bandpass
+	 * @webBrief Set the cutoff frequency for the filter.
 	 * @param freq Cutoff frequency between 0 and 20000
 	 **/
 	public void freq(float freq) {
 		this.left.frequency.set(freq);
 		this.right.frequency.set(freq);
 	}
-
+	
 	public void process(SoundObject input, float freq) {
 		this.freq(freq);
 		this.process(input);
@@ -54,7 +57,8 @@ public class BandPass extends Effect<FilterBandPass> {
 
 	/**
 	 * Sets frequency and bandwidth of the filter with one method. 
-	 * @webref sound
+	 * @webref bandpass
+	 * @webBrief Sets frequency and bandwidth of the filter with one method.
 	 * @param freq Set the frequency
 	 * @param bw Set the bandwidth
 	 **/

--- a/src/processing/sound/BeatDetector.java
+++ b/src/processing/sound/BeatDetector.java
@@ -14,7 +14,10 @@ import processing.core.PApplet;
  * implementation does not return a tempo or BPM (beats per minute) value — it
  * can only tell you whether the current moment of audio contains a beat or not.
  *
- * @webref sound
+ * @webref analysis
+ * @webBrief Looks for spikes in the energy of an audio signal
+ * which are often associated with rhythmic musical beats and can be used to trigger a
+ * response whenever the incoming audio signal pulses.
  **/
 public class BeatDetector extends Analyzer {
   private final BeatDetectorUGen detector;
@@ -44,7 +47,8 @@ public class BeatDetector extends Analyzer {
    * A "beat" is defined as a spike in the energy of the audio signal — it may
    * or may not coincide exactly with a musical beat.
    *
-   * @webref sound
+   * @webref beatdetector
+   * @webBrief Returns whether or not the current moment of audio contains a beat or not.
    *
    * @return True if the audio signal currently contains a beat, false otherwise.
    */
@@ -62,7 +66,8 @@ public class BeatDetector extends Analyzer {
    * can tune this appropriately if you notice the detector returning too many
    * false positive beats.
    *
-   * @webref sound
+   * @webref beatdetector
+   * @webBrief Sets the sensitivity, in milliseconds, of the beat detection algorithm.
    *
    * @param sensitivity Sensitivity in milliseconds. Must be a positive number.
    */
@@ -71,7 +76,9 @@ public class BeatDetector extends Analyzer {
   }
 
   /**
-   * @webref sound
+   * Sets the sensitivity of the beat detector.
+   * @webref beatdetector
+   * @webBrief Sets the sensitivity of the beat detector.
    *
    * @return The sensitivity in milliseconds.
    */

--- a/src/processing/sound/BrownNoise.java
+++ b/src/processing/sound/BrownNoise.java
@@ -4,14 +4,14 @@ import processing.core.PApplet;
 
 /**
  * This is a brown noise generator. Brown noise has a decrease of 6db per octave.
- * @webref sound
+ * @webref noise
+ * @webBrief This is a brown noise generator.
  * @param parent typically use "this"	
  **/
 public class BrownNoise extends Noise<com.jsyn.unitgen.BrownNoise> {
 
 	/**
 	 * @param parent typically use "this"	
-	 * @webref sound
 	 */
 	public BrownNoise(PApplet parent) {
 		super(parent, new com.jsyn.unitgen.BrownNoise());
@@ -36,31 +36,34 @@ public class BrownNoise extends Noise<com.jsyn.unitgen.BrownNoise> {
 	}
 
 	/**
-	 * Start the generator
+	 * Start the generator.
 	 * @param amp the amplitude of the noise as a value from 0.0 (complete silence) to 1.0 (full volume)
 	 * @param add offset the output of the noise by given value
 	 * @param pos pan the generator in stereo panorama. Allowed values are between -1.0 and 1.0.
-	 * @webref sound
+	 * @webref brownnoise
+	 * @webBrief Start the generator.
 	 **/
 	public void play(float amp, float add, float pos) {
 		super.play(amp, add, pos);
 	}
 
 	/**
-	 * Set multiple parameters at once.
+	 * Sets <b>amplitude</b>, <b>add</b> and <b>pan</b> position with one method. 
 	 * @param amp the amplitude of the noise as a value from 0.0 (complete silence) to 1.0 (full volume)
 	 * @param add offset the output of the noise by given value
 	 * @param pos pan the generator in stereo panorama. Allowed values are between -1.0 and 1.0.
-	 * @webref sound
+	 * @webref brownnoise
+	 * @webBrief Sets amplitude, add and pan position with one method. 
 	 **/
 	public void set(float amp, float add, float pos) {
 		super.set(amp, add, pos);
 	}
 
 	/**
-	 * Change the amplitude/volume of this sound.
+	 * Changes the amplitude/volume of the noise generator. Allowed values are between 0.0 and 1.0.
 	 * @param amp the amplitude of the noise as a value from 0.0 (complete silence) to 1.0 (full volume)
-	 * @webref sound
+	 * @webref brownnoise
+	 * @webBrief Changes the amplitude/volume of the noise generator.
 	 **/
 	public void amp(float amp) {
 		// the JSyn Brownian noise generator can drift to exceed one, so tone down the volume a bit
@@ -68,20 +71,22 @@ public class BrownNoise extends Noise<com.jsyn.unitgen.BrownNoise> {
 	}
 
 	/**
-	 * Offset the output of this generator by a fixed value
+	 * Offset the output of this generator by a fixed value.
 	 * @param add offset the output of the generator by the given value
-	 * @webref sound
+	 * @webref brownnoise
+	 * @webBrief Offset the output of this generator by a fixed value.
 	 **/
 	public void add(float add) {
 		super.add(add);
 	}
 
 	/**
-	 * Move the sound in a stereo panorama.
+	 * Pan the generator in a stereo panorama. -1.0 pans to the left channel and 1.0 to the right channel.
 	 * @param pos
 	 *            the panoramic position of this sound unit from -1.0 (left) to 1.0
 	 *            (right).
-	 * @webref sound
+	 * @webref brownnoise
+	 * @webBrief Pan the generator in a stereo panorama.
 	 **/
 	public void pan(float pos) {
 		super.pan(pos);
@@ -89,7 +94,8 @@ public class BrownNoise extends Noise<com.jsyn.unitgen.BrownNoise> {
 
 	/**
 	 * Stop the generator
-	 * @webref sound
+	 * @webref brownnoise
+	 * @webBrief Stops the Brown Noise generator.
 	 **/
 	public void stop() {
 		super.stop();

--- a/src/processing/sound/Delay.java
+++ b/src/processing/sound/Delay.java
@@ -5,7 +5,8 @@ import processing.core.PApplet;
 /**
  * This is a simple delay effect.
  * 
- * @webref sound
+ * @webref effects
+ * @webBrief This is a simple delay effect.
  * @param parent
  *            PApplet: typically use "this"
  **/
@@ -21,9 +22,10 @@ public class Delay extends Effect<JSynDelay> {
 	}
 
 	/**
-	 * Start the delay effect
+	 * Start the delay effect.
 	 * 
-	 * @webref sound
+	 * @webref delay
+     * @webBrief Start the delay effect.
 	 * @param input
 	 *            Input audio source
 	 * @param maxDelayTime Maximum delay time in seconds.
@@ -43,9 +45,10 @@ public class Delay extends Effect<JSynDelay> {
 	}
 
 	/**
-	 * Set delay time and feedback values at once
+	 * Set delay time and feedback values at once.
 	 * 
-	 * @webref sound
+	 * @webref delay
+	 * @webBrief Set delay time and feedback values at once.
 	 * @param delayTime
 	 *            Maximum delay time in seconds.
 	 * @param feedback
@@ -59,7 +62,8 @@ public class Delay extends Effect<JSynDelay> {
 	/**
 	 * Changes the delay time of the effect.
 	 * 
-	 * @webref sound
+	 * @webref delay
+	 * @webBrief Changes the delay time of the effect.
 	 * @param delayTime
 	 *            Delay time in seconds.
 	 **/
@@ -72,7 +76,8 @@ public class Delay extends Effect<JSynDelay> {
 	/**
 	 * Change the feedback of the delay effect.
 	 * 
-	 * @webref sound
+	 * @webref delay
+	 * @webBrief Change the feedback of the delay effect.
 	 * @param feedback
 	 *            Feedback amount as a float.
 	 **/

--- a/src/processing/sound/Env.java
+++ b/src/processing/sound/Env.java
@@ -7,8 +7,9 @@ import com.softsynth.shared.time.TimeStamp;
 import processing.core.PApplet;
 
 /**
-* This is an ASR (Attack Sustain Release) Envelope Generator
-* @webref sound
+* This is an ASR (Attack Sustain Release) Envelope Generator.
+* @webref envelopes
+* @webBrief This is an ASR (Attack Sustain Release) Envelope Generator.
 * @param parent PApplet: typically use "this"
 **/
 public class Env {
@@ -18,8 +19,9 @@ public class Env {
 	}
 
 	/**
-	* Triggers the envelope
-	* @webref sound
+	* Triggers the envelope.
+	* @webref env
+	* @webBrief Triggers the envelope.
 	* @param input Input sound source
 	* @param attackTime Attack time value as a float.
 	* @param sustainTime Sustain time value as a float. 

--- a/src/processing/sound/FFT.java
+++ b/src/processing/sound/FFT.java
@@ -9,7 +9,8 @@ import processing.core.PApplet;
  * power spectrum of an audio stream the moment it is queried with the analyze()
  * method.
  * 
- * @webref sound
+ * @webref analysis
+ * @webBrief This is a Fast Fourier Transform (FFT) analyzer.
  **/
 public class FFT extends Analyzer {
 
@@ -28,7 +29,6 @@ public class FFT extends Analyzer {
 	 *            number of frequency bands for the FFT as an integer (default 512).
 	 *            This parameter needs to be a power of 2 (e.g. 16, 32, 64, 128,
 	 *            ...).
-	 * @webref sound
 	 */
 	public FFT(PApplet parent, int bands) {
 		super(parent);
@@ -66,14 +66,15 @@ public class FFT extends Analyzer {
 	}
 
 	/**
-	 * Calculates the current frequency spectrum from the input source.
+	 * Calculates the current frequency spectrum and returns it as an array with as many elements as frequency bands.
 	 *
 	 * @param value
 	 *            an array with as many elements as this FFT analyzer's number of
 	 *            frequency bands
 	 * @return The current frequency spectrum of the input source. The array has as
 	 *         many elements as this FFT analyzer's number of frequency bands.
-	 * @webref sound
+	 * @webref fft
+	 * @webBrief Calculates the current frequency spectrum and returns it as an array with as many elements as frequency bands.
 	 **/
 	public float[] analyze(float[] value) {
 		if (this.input == null) {
@@ -92,7 +93,8 @@ public class FFT extends Analyzer {
 	 * @param input
 	 *            the input sound source. Can be an oscillator, noise generator,
 	 *            SoundFile or AudioIn.
-	 * @webref sound
+	 * @webref fft
+	 * @webBrief Define the audio input for the analyzer.
 	 **/
 	public void input(SoundObject input) {
 		super.input(input);

--- a/src/processing/sound/HighPass.java
+++ b/src/processing/sound/HighPass.java
@@ -5,8 +5,9 @@ import com.jsyn.unitgen.FilterHighPass;
 import processing.core.PApplet;
 
 /**
- * This is a high pass filter
- * @sound webref
+ * This is a high pass filter.
+ * @webref effects
+ * @webBrief This is a high pass filter.
  * @param parent PApplet: typically use "this"
  **/
 public class HighPass extends Effect<FilterHighPass> {
@@ -21,8 +22,9 @@ public class HighPass extends Effect<FilterHighPass> {
 	}
 
 	/**
-	 * Set the cut off frequency for the filter
-	 * @webref sound
+	 * Set the cut off frequency for the filter.
+	 * @webref highpass
+	 * @webBrief Set the cut off frequency for the filter.
 	 * @param freq the cutoff frequency in Hertz
 	 */
 	public void freq(float freq) {

--- a/src/processing/sound/LowPass.java
+++ b/src/processing/sound/LowPass.java
@@ -5,8 +5,8 @@ import com.jsyn.unitgen.FilterLowPass;
 import processing.core.PApplet;
 
 /**
- * This is a low pass filter
- * @sound webref
+ * This is a low pass filter.
+ * @webref effects
  * @param parent PApplet: typically use "this"
  **/
 public class LowPass extends Effect<FilterLowPass> {
@@ -21,8 +21,9 @@ public class LowPass extends Effect<FilterLowPass> {
 	}
 
 	/**
-	 * Set the cut off frequency for the filter
-	 * @webref sound
+	 * Set the cut off frequency for the filter.
+	 * @webref lowpass
+	 * @webBrief Set the cut off frequency for the filter.
 	 * @param freq the cutoff frequency in Hertz
 	 */
 	public void freq(float freq) {

--- a/src/processing/sound/PinkNoise.java
+++ b/src/processing/sound/PinkNoise.java
@@ -4,13 +4,13 @@ import processing.core.PApplet;
 
 /**
 * This is a pink noise generator. Pink Noise has a decrease of 3dB per octave.
-* @webref sound
+* @webref noise
+* @webBrief This is a pink noise generator.
 **/
 public class PinkNoise extends Noise<com.jsyn.unitgen.PinkNoise> {
 
 	/**
 	 * @param parent typically use "this"	
-	 * @webref sound
 	 */
 	public PinkNoise(PApplet parent) {
 		super(parent, new com.jsyn.unitgen.PinkNoise());
@@ -33,22 +33,24 @@ public class PinkNoise extends Noise<com.jsyn.unitgen.PinkNoise> {
 	}
 
 	/**
-	 * Start the generator
+	 * Start the generator.
 	 * @param amp the amplitude of the noise as a value from 0.0 (complete silence) to 1.0 (full volume)
 	 * @param add offset the output of the noise by given value
 	 * @param pos pan the generator in stereo panorama. Allowed values are between -1.0 and 1.0.
-	 * @webref sound
+	 * @webref pinknoise
+	 * @webBrief Start the generator.
 	 **/
 	public void play(float amp, float add, float pos) {
 		super.play(amp, add, pos);
 	}
 
 	/**
-	 * Set multiple parameters at once.
+	 * Sets amplitude, add and pan position with one method.
 	 * @param amp the amplitude of the noise as a value from 0.0 (complete silence) to 1.0 (full volume)
 	 * @param add offset the output of the noise by given value
 	 * @param pos pan the generator in stereo panorama. Allowed values are between -1.0 and 1.0.
-	 * @webref sound
+	 * @webref pinknoise
+	 * @webBrief Sets amplitude, add and pan position with one method.
 	 **/
 	public void set(float amp, float add, float pos) {
 		super.set(amp, add, pos);
@@ -57,7 +59,8 @@ public class PinkNoise extends Noise<com.jsyn.unitgen.PinkNoise> {
 	/**
 	 * Change the amplitude/volume of this sound.
 	 * @param amp the amplitude of the noise as a value from 0.0 (complete silence) to 1.0 (full volume)
-	 * @webref sound
+	 * @webref pinknoise
+	 * @webBrief Change the amplitude/volume of this sound.
 	 **/
 	public void amp(float amp) {
 		// the JSyn Brownian noise generator can drift to exceed one, so tone down the volume a bit
@@ -65,28 +68,31 @@ public class PinkNoise extends Noise<com.jsyn.unitgen.PinkNoise> {
 	}
 
 	/**
-	 * Offset the output of this generator by a fixed value
+	 * Offset the output of this generator by a fixed value.
 	 * @param add offset the output of the generator by the given value
-	 * @webref sound
+	 * @webref pinknoise
+	 * @webBrief Offset the output of this generator by a fixed value.
 	 **/
 	public void add(float add) {
 		super.add(add);
 	}
 
 	/**
-	 * Move the sound in a stereo panorama.
+	 * Pan the generator in a stereo panorama. -1.0 pans to the left channel and 1.0 to the right channel.
 	 * @param pos
 	 *            the panoramic position of this sound unit from -1.0 (left) to 1.0
 	 *            (right).
-	 * @webref sound
+	 * @webref pinknoise
+	 * @webBrief Pan the generator in a stereo panorama.
 	 **/
 	public void pan(float pos) {
 		super.pan(pos);
 	}
 
 	/**
-	 * Stop the generator
-	 * @webref sound
+	 * Stops the Pink Noise generator.
+	 * @webref pinknoise
+	 * @webBrief Stops the Pink Noise generator.
 	 **/
 	public void stop() {
 		super.stop();

--- a/src/processing/sound/Pulse.java
+++ b/src/processing/sound/Pulse.java
@@ -6,12 +6,12 @@ import processing.core.PApplet;
 
 /**
  * This is a simple Pulse oscillator.
- * @webref sound
+ * @webref oscillators
+ * @webBrief This is a simple Pulse oscillator.
  **/
 public class Pulse extends Oscillator<PulseOscillator> {
 
 	/**
-	 * @webref sound
 	 * @param parent typically use "this"
 	 */
 	public Pulse(PApplet parent) {
@@ -19,9 +19,10 @@ public class Pulse extends Oscillator<PulseOscillator> {
 	}
 
 	/**
-	 * Set the pulse width of the oscillator.
+	 * Changes the pulse width of the pulse oscillator. Allowed values are between 0.0 and 1.0.
 	 * 
-	 * @webref sound
+	 * @webref pulse
+	 * @webBrief Changes the pulse width of the pulse oscillator.
 	 * @param width
 	 *            The relative pulse width of the oscillator as a float value
 	 *            between 0.0 and 1.0 (exclusive)
@@ -33,7 +34,7 @@ public class Pulse extends Oscillator<PulseOscillator> {
 	/**
 	 * Set multiple parameters at once
 	 * 
-	 * @webref sound
+	 * @webref pulse
 	 * @param freq
 	 *            The frequency value of the oscillator in Hz.
 	 * @param width
@@ -66,12 +67,13 @@ public class Pulse extends Oscillator<PulseOscillator> {
 	}
 
 	/**
-	 * Starts the oscillator
+	 * Starts the oscillator.
 	 * @param freq The frequency value of the oscillator in Hz.
 	 * @param amp The amplitude of the oscillator as a value between 0.0 and 1.0.
 	 * @param add Offset the output of the oscillator by given value
 	 * @param pos The panoramic position of the oscillator as a float from -1.0 to 1.0.
-	 * @webref sound
+	 * @webref pulse 
+	 * @webBrief Starts the oscillator
 	 **/
 	public void play(float freq, float amp, float add, float pos) {
 		super.play(freq, amp, add, pos);
@@ -82,8 +84,9 @@ public class Pulse extends Oscillator<PulseOscillator> {
 	}
 	
 	/**
-	 * Set the frequency of the oscillator in Hz.
-	 * @webref sound
+	 * Changes the frequency of the pulse oscillator in Hz.
+	 * @webref pulse
+	 * @webBrief Changes the frequency of the pulse oscillator in Hz.
 	 * @param freq A floating point value of the oscillator in Hz.
 	 **/
 	public void freq(float freq) {
@@ -91,9 +94,10 @@ public class Pulse extends Oscillator<PulseOscillator> {
 	}
 
 	/**
-	 * Change the amplitude/volume of this sound.
+	 * Changes the amplitude/volume of the pulse oscillator. Allowed values are between 0.0 and 1.0.
 	 *
-	 * @webref sound
+	 * @webref pulse
+	 * @webBrief Changes the amplitude/volume of the pulse oscillator.
 	 * @param amp
 	 *            A float value between 0.0 (complete silence) and 1.0 (full volume)
 	 *            controlling the amplitude/volume of this sound.
@@ -103,9 +107,10 @@ public class Pulse extends Oscillator<PulseOscillator> {
 	}
 
 	/**
-	 * Offset the output of this generator by given value
+	 * Offset the output of this generator by given value.
 	 *
-	 * @webref sound
+	 * @webref pulse
+	 * @webBrief Offset the output of this generator by given value.
 	 * @param add Offset the output of the oscillator by given value
 	 **/
 	public void add(float add) {
@@ -113,9 +118,10 @@ public class Pulse extends Oscillator<PulseOscillator> {
 	}
 
 	/**
-	 * Move the sound in a stereo panorama.
+	 * Pan the oscillator in a stereo panorama. -1.0 pans to the left channel and 1.0 to the right channel.
 	 *
-	 * @webref sound
+	 * @webref pulse
+	 * @webBrief Pan the oscillator in a stereo panorama.
 	 * @param pos
 	 *            The panoramic position of this sound unit as a float from -1.0
 	 *            (left) to 1.0 (right).
@@ -125,9 +131,10 @@ public class Pulse extends Oscillator<PulseOscillator> {
 	}
 
 	/**
-	 * Stop the oscillator.
+	 * Stops the Sine Oscillator generator.
 	 *
-	 * @webref sound
+	 * @webref pulse
+	 * @webBrief Stops the Sine Oscillator generator.
 	 **/
 	public void stop() {
 		super.stop();

--- a/src/processing/sound/Reverb.java
+++ b/src/processing/sound/Reverb.java
@@ -5,7 +5,8 @@ import processing.core.PApplet;
 /**
  * This is a simple reverb effect.
  * 
- * @webref sound
+ * @webref effects
+ * @webBrief This is a simple reverb effect.
  * @param parent
  *            PApplet: typically use "this"
  **/
@@ -23,9 +24,10 @@ public class Reverb extends Effect<JSynReverb> {
 	
 //	public void process(SoundObject input, float room, float damp, float wet) {
 	/**
-	 * Change the damping of the reverb effect
+	 * Changes the damping factor of the reverb effect.
 	 * 
-	 * @webref sound
+	 * @webref reverb
+	 * @webBrief Changes the damping factor of the reverb effect.
 	 * @param damp
 	 *            A float value controlling the damping factor of the reverb
 	 **/
@@ -39,7 +41,8 @@ public class Reverb extends Effect<JSynReverb> {
 	/**
 	 * Change the room size of the reverb effect.
 	 * 
-	 * @webref sound
+	 * @webref reverb
+	 * @webBrief Change the room size of the reverb effect.
 	 * @param room
 	 *            A float value controlling the room size of the effect.
 	 **/
@@ -51,9 +54,10 @@ public class Reverb extends Effect<JSynReverb> {
 	}
 
 	/**
-	 * Set multiple parameters at once
+	 * Set multiple parameters of the reverb. Parameters have to be in the right order.
 	 * 
-	 * @webref sound
+	 * @webref reverb
+	 * @webBrief Set multiple parameters of the reverb.
 	 * @param room
 	 *            A value controlling the room size of the effect
 	 * @param damp
@@ -68,9 +72,10 @@ public class Reverb extends Effect<JSynReverb> {
 	}
 
 	/**
-	 * Change the dry/wet ratio of the delay effect
+	 * Change the wet/dry ratio of the reverb.
 	 * 
-	 * @webref sound
+	 * @webref reverb
+	 * @webBrief Change the wet/dry ratio of the reverb.
 	 * @param wet
 	 *            A float value controlling the wet/dry ratio of the reverb. TODO
 	 *            document

--- a/src/processing/sound/SawOsc.java
+++ b/src/processing/sound/SawOsc.java
@@ -5,13 +5,13 @@ import com.jsyn.unitgen.SawtoothOscillator;
 import processing.core.PApplet;
 
 /**
- * This is a simple Saw Wave Oscillator 
- * @webref sound
+ * This is a simple Saw Wave Oscillator.
+ * @webref oscillators
+ * @webBrief This is a simple Saw Wave Oscillator.
  **/
 public class SawOsc extends Oscillator<SawtoothOscillator> {
 
 	/**
-	 * @webref sound
 	 * @param parent typically use "this"
 	 */
 	public SawOsc(PApplet parent) {
@@ -34,20 +34,22 @@ public class SawOsc extends Oscillator<SawtoothOscillator> {
 	}
 
 	/**
-	 * Starts the oscillator
+	 * Starts the oscillator.
 	 * @param freq The frequency value of the oscillator in Hz.
 	 * @param amp The amplitude of the oscillator as a value between 0.0 and 1.0.
 	 * @param add Offset the output of the oscillator by given value
 	 * @param pos The panoramic position of the oscillator as a float from -1.0 to 1.0.
-	 * @webref sound
+	 * @webref sawosc
+	 * @webBrief Starts the oscillator. 
 	 **/
 	public void play(float freq, float amp, float add, float pos) {
 		super.play(freq, amp, add, pos);
 	}
 
 	/**
-	 * Set multiple parameters at once
-	 * @webref sound
+	 * Set multiple parameters at once.
+	 * @webref sawosc
+	 * @webBrief Set multiple parameters at once.
 	 * @param freq The frequency value of the oscillator in Hz.
 	 * @param amp The amplitude of the oscillator as a value between 0.0 and 1.0.
 	 * @param add Offset the output of the oscillator by given value
@@ -59,7 +61,8 @@ public class SawOsc extends Oscillator<SawtoothOscillator> {
 	
 	/**
 	 * Set the frequency of the oscillator in Hz.
-	 * @webref sound
+	 * @webref sawosc
+	 * @webBrief Set the frequency of the oscillator in Hz.
 	 * @param freq A floating point value of the oscillator in Hz.
 	 **/
 	public void freq(float freq) {
@@ -67,9 +70,10 @@ public class SawOsc extends Oscillator<SawtoothOscillator> {
 	}
 
 	/**
-	 * Change the amplitude/volume of this sound.
+	 * Changes the amplitude/volume of the saw oscillator. Allowed values are between 0.0 and 1.0.
 	 *
-	 * @webref sound
+	 * @webref sawosc
+	 * @webBrief Changes the amplitude/volume of the saw oscillator.
 	 * @param amp
 	 *            A float value between 0.0 (complete silence) and 1.0 (full volume)
 	 *            controlling the amplitude/volume of this sound.
@@ -79,9 +83,10 @@ public class SawOsc extends Oscillator<SawtoothOscillator> {
 	}
 
 	/**
-	 * Offset the output of this generator by given value
+	 * Offset the output of this generator by given value.
 	 *
-	 * @webref sound
+	 * @webref sawosc
+	 * @webBrief Offset the output of this generator by given value.
 	 * @param add Offset the output of the oscillator by given value
 	 **/
 	public void add(float add) {
@@ -91,8 +96,9 @@ public class SawOsc extends Oscillator<SawtoothOscillator> {
 	/**
 	 * Move the sound in a stereo panorama.
 	 *
-	 * @webref sound
-	 * @param pos
+	 * @webref sawosc
+	 * @webBrief Move the sound in a stereo panorama.
+	 * @param pos Move the sound in a stereo panorama.
 	 *            The panoramic position of this sound unit as a float from -1.0
 	 *            (left) to 1.0 (right).
 	 **/
@@ -103,7 +109,8 @@ public class SawOsc extends Oscillator<SawtoothOscillator> {
 	/**
 	 * Stop the oscillator.
 	 *
-	 * @webref sound
+	 * @webref sawosc
+	 * @webBrief Move the sound in a stereo panorama.
 	 **/
 	public void stop() {
 		super.stop();

--- a/src/processing/sound/SinOsc.java
+++ b/src/processing/sound/SinOsc.java
@@ -5,14 +5,14 @@ import com.jsyn.unitgen.SineOscillator;
 import processing.core.PApplet;
 
 /**
- * This is a simple Sine Wave Oscillator
+ * This is a simple Sine Wave Oscillator.
  *
- * @webref sound
+ * @webref oscillators
+ * @webBrief This is a simple Sine Wave Oscillator.
  **/
 public class SinOsc extends Oscillator<SineOscillator> {
 
 	/**
-	 * @webref sound
 	 * @param parent
 	 *            typically use "this"
 	 */
@@ -36,7 +36,7 @@ public class SinOsc extends Oscillator<SineOscillator> {
 	}
 
 	/**
-	 * Starts the oscillator
+	 * Starts the oscillator.
 	 *
 	 * @param freq
 	 *            The frequency value of the oscillator in Hz.
@@ -47,16 +47,18 @@ public class SinOsc extends Oscillator<SineOscillator> {
 	 * @param pos
 	 *            The panoramic position of the oscillator as a float from -1.0 to
 	 *            1.0.
-	 * @webref sound
+	 * @webref sinosc
+	 * @webBrief Starts the oscillator.
 	 **/
 	public void play(float freq, float amp, float add, float pos) {
 		super.play(freq, amp, add, pos);
 	}
 
 	/**
-	 * Set multiple parameters at once
+	 * Set multiple parameters at once.
 	 *
-	 * @webref sound
+	 * @webref sinosc
+	 * @webBrief Set multiple parameters at once.
 	 * @param freq
 	 *            The frequency value of the oscillator in Hz.
 	 * @param amp
@@ -74,7 +76,8 @@ public class SinOsc extends Oscillator<SineOscillator> {
 	/**
 	 * Set the frequency of the oscillator in Hz.
 	 *
-	 * @webref sound
+	 * @webref sinosc
+	 * @webBrief Set the frequency of the oscillator in Hz.
 	 * @param freq
 	 *            A floating point value of the oscillator in Hz.
 	 **/
@@ -83,9 +86,10 @@ public class SinOsc extends Oscillator<SineOscillator> {
 	}
 
 	/**
-	 * Change the amplitude/volume of this sound.
+	 * Changes the amplitude/volume of the sine oscillator. Allowed values are between 0.0 and 1.0.
 	 *
-	 * @webref sound
+	 * @webref sinosc
+	 * @webBrief Changes the amplitude/volume of the sine oscillator.
 	 * @param amp
 	 *            A float value between 0.0 (complete silence) and 1.0 (full volume)
 	 *            controlling the amplitude/volume of this sound.
@@ -95,9 +99,10 @@ public class SinOsc extends Oscillator<SineOscillator> {
 	}
 
 	/**
-	 * Offset the output of this generator by given value
+	 * Offset the output of this generator by given value.
 	 *
-	 * @webref sound
+	 * @webref sinosc
+	 * @webBrief Offset the output of this generator by given value.
 	 * @param add
 	 *            Offset the output of the oscillator by given value
 	 **/
@@ -106,9 +111,10 @@ public class SinOsc extends Oscillator<SineOscillator> {
 	}
 
 	/**
-	 * Move the sound in a stereo panorama.
+	 * Pan the oscillator in a stereo panorama. -1.0 pans to the left channel and 1.0 to the right channel.
 	 *
-	 * @webref sound
+	 * @webref sinosc
+	 * @webBrief Pan the oscillator in a stereo panorama.
 	 * @param pos
 	 *            the panoramic position of this sound unit from -1.0 (left) to 1.0
 	 *            (right).
@@ -120,7 +126,8 @@ public class SinOsc extends Oscillator<SineOscillator> {
 	/**
 	 * Stop the oscillator.
 	 *
-	 * @webref sound
+	 * @webref sinosc
+	 * @webBrief Stops the oscillator.
 	 **/
 	public void stop() {
 		super.stop();

--- a/src/processing/sound/Sound.java
+++ b/src/processing/sound/Sound.java
@@ -12,9 +12,10 @@ import processing.core.PApplet;
  * rate or global output volume.
  *
  * Information on available input and output devices can be obtained by calling
- * Sound.list()
+ * <b>Sound.list()</b>
  * 
- * @webref sound
+ * @webref configuration
+ * @webBrief This class can be used for configuring the Processing Sound library.
  */
 public class Sound {
 
@@ -39,7 +40,6 @@ public class Sound {
 	 *            captured
 	 * @param volume
 	 *            the overall output volume of the library (default 1.0)
-	 * @webref sound
 	 */
 	public Sound(PApplet parent, int sampleRate, int outputDevice, int inputDevice, float volume) {
 		this(parent);
@@ -52,10 +52,17 @@ public class Sound {
 	/**
 	 * Print and return information on available audio devices and their number of
 	 * input/output channels.
+	 * Under normal circumstances you will not want to call <b>Sound.list()</b> in 
+	 * your actual sketch code, but only for testing to figure out which sound cards 
+	 * are available on a new system and how to select them. However, if the order 
+	 * of devices on your system is prone to fluctuate from reboot to reboot, you 
+	 * can also use the device name array returned by the function to automate device 
+	 * selection by name in your own code.
 	 * 
 	 * @return an array giving the names of all audio devices available on this
 	 *         computer
 	 * @webref sound
+	 * @webBrief Print and return information on available audio devices and their number of input/output channels.
 	 */
 	public static String[] list() {
 		AudioDeviceManager audioManager = Engine.getAudioManager();
@@ -86,6 +93,7 @@ public class Sound {
 	 *            the sample rate to be used by the synthesis engine (default 44100)
 	 * @return the internal sample rate used by the synthesis engine
 	 * @webref sound
+	 * @webBrief Get or set the internal sample rate of the synthesis engine.
 	 */
 	public int sampleRate(int sampleRate) {
 		this.engine.setSampleRate(sampleRate);
@@ -94,12 +102,16 @@ public class Sound {
 
 	/**
 	 * Choose the device (sound card) which should be used for grabbing audio input
-	 * using AudioIn.
+	 * using AudioIn.  Note that this setting affects the choice of sound card, which 
+	 * is not necessarily the same as the number of the input channel. If your sound 
+	 * card has more than one input channel, you can specify which channel to use in
+	 * the constructor of the AudioIn class.
 	 * 
 	 * @param deviceId
 	 *            the device id obtained from Sound.list()
 	 * @seealso Sound.list()
 	 * @webref sound
+	 * @webBrief Choose the device (sound card) which should be used for grabbing audio input using AudioIn.
 	 */
 	public void inputDevice(int deviceId) {
 		this.engine.selectInputDevice(deviceId);
@@ -107,12 +119,13 @@ public class Sound {
 
 	/**
 	 * Choose the device (sound card) which the Sound library's audio output should
-	 * be sent to.
+	 * be sent to. The output device should support stereo output (2 channels).
 	 * 
 	 * @param deviceId
 	 *            the device id obtained from list()
 	 * @seealso list()
 	 * @webref sound
+	 * @webBrief Choose the device (sound card) which the Sound library's audio output should be sent to.
 	 */
 	public void outputDevice(int deviceId) {
 		this.engine.selectOutputDevice(deviceId);
@@ -125,6 +138,7 @@ public class Sound {
 	 *            the desired output volume, normally between 0.0 and 1.0 (default
 	 *            is 1.0)
 	 * @webref sound
+	 * @webBrief Set the overall output volume of the Processing sound library.
 	 */
 	public void volume(float volume) {
 		this.engine.setVolume(volume);

--- a/src/processing/sound/SoundFile.java
+++ b/src/processing/sound/SoundFile.java
@@ -17,7 +17,9 @@ import processing.core.PApplet;
  * This is a Soundfile player which allows to play back and manipulate sound
  * files. Supported formats are: WAV, AIF/AIFF, and MP3.
  * 
- * @webref sound
+ * MP3 decoding can be very slow on ARM processors (Android/Raspberry Pi), we generally recommend you use lossless WAV or AIF files.
+ * @webref sampling
+ * @webBrief This is a Soundfile Player which allows to play back and manipulate soundfiles.
  **/
 public class SoundFile extends AudioSample {
 
@@ -41,7 +43,6 @@ public class SoundFile extends AudioSample {
 	 *            Note that caching essentially disables garbage collection for the
 	 *            SoundFile data, so if you are planning to load a large number of audio
 	 *            files, you should set this to false.
-	 * @webref sound
 	 */
 	public SoundFile(PApplet parent, String path, boolean cache) {
 		super(parent);
@@ -111,7 +112,10 @@ public class SoundFile extends AudioSample {
 	 * 
 	 * @return true if the sample was removed from the cache, false if it wasn't
 	 *.        actually cached in the first place.
-	 * @webref sound
+	 * @webref soundfile
+	 * @webBrief Remove this SoundFile's decoded audio sample from the cache, allowing
+	 * it to be garbage collected once there are no more references to this
+	 * SoundFile.
 	 **/
 	public boolean removeFromCache() {
 		return SoundFile.SAMPLECACHE.values().remove(this.sample);
@@ -121,23 +125,26 @@ public class SoundFile extends AudioSample {
 	// are required for the reference to build the corresponding pages.
 
 	/**
-	 * Returns the number of channels of the soundfile.
+	 * Returns the number of channels of the soundfile as an int (1 for mono, 2 for stereo).
 	 * 
 	 * @return Returns the number of channels of the soundfile (1 for mono, 2 for
 	 *         stereo)
-	 * @webref sound
+	 * @webref soundfile
+	 * @webBrief Returns the number of channels of the soundfile as an int (1 for mono, 2 for stereo).
 	 **/
 	public int channels() {
 		return super.channels();
 	}
 
 	/**
-	 * Cues the playhead to a fixed position in the soundfile.
+	 * Cues the playhead to a fixed position in the soundfile. Note that <b>cue()</b> only 
+	 * affects the playhead for future calls to <b>play()</b>, but not to <b>loop()</b>.
 	 * 
 	 * @param time
 	 *            position in the soundfile that the next playback should start
 	 *            from, in seconds.
-	 * @webref sound
+	 * @webref soundfile
+	 * @webBrief Cues the playhead to a fixed position in the soundfile.
 	 **/
 	public void cue(float time) {
 		super.cue(time);
@@ -146,7 +153,8 @@ public class SoundFile extends AudioSample {
 	/**
 	 * Returns the duration of the soundfile in seconds.
 	 * 
-	 * @webref sound
+	 * @webref soundfile
+	 * @webBrief Returns the duration of the soundfile in seconds.
 	 * @return The duration of the soundfile in seconds.
 	 **/
 	public float duration() {
@@ -156,7 +164,8 @@ public class SoundFile extends AudioSample {
 	/**
 	 * Returns the number of frames of this soundfile.
 	 * 
-	 * @webref sound
+	 * @webref soundfile
+	 * @webBrief Returns the number of frames of this soundfile.
 	 * @return The number of frames of this soundfile.
 	 **/
 	public int frames() {
@@ -185,7 +194,8 @@ public class SoundFile extends AudioSample {
 
 	/**
 	 * Starts the playback of the soundfile. Only plays to the end of the
-	 * audiosample once.
+	 * audiosample once. If <b>cue()</b> or <b>pause()</b> were called previously, playback 
+	 * will resume from the cued position.
 	 * 
 	 * @param rate
 	 *            relative playback rate to use. 1 is the original speed. 0.5 is
@@ -202,7 +212,8 @@ public class SoundFile extends AudioSample {
 	 *            seconds.
 	 * @param add
 	 *            offset the output of the generator by the given value
-	 * @webref sound
+	 * @webref soundfile
+	 * @webBrief Starts the playback of the soundfile.
 	 **/
 	public void play(float rate, float pos, float amp, float add, float cue) {
 		super.play(rate, pos, amp, add, cue);
@@ -210,9 +221,11 @@ public class SoundFile extends AudioSample {
 
 
 	/**
-	 * Jump to a specific position in the soundfile while continuing to play.
+	 * Jump to a specific position in the soundfile while continuing to play 
+	 * (or starting to play if it wasn't playing already).
 	 * 
-	 * @webref sound
+	 * @webref soundfile
+	 * @webBrief Jump to a specific position in the soundfile while continuing to play (or starting to play if it wasn't playing already).
 	 * @param time
 	 *            position to jump to, in seconds.
 	 **/
@@ -221,11 +234,12 @@ public class SoundFile extends AudioSample {
 	}
 
 	/**
-	 * Stop the playback of the file, but cue it to the current position so that the
-	 * next call to play() will continue playing where it left off.
+	 * Stop the playback of the file, but cue it to the current position. The
+	 * next call to <b>play()</b> will continue playing where it left off.
 	 * 
 	 * @see stop
-	 * @webref sound
+	 * @webref soundfile
+	 * @webBrief Stop the playback of the file, but cue it to the current position.
 	 */
 	public void pause() {
 		super.pause();
@@ -233,9 +247,10 @@ public class SoundFile extends AudioSample {
 
 	/**
 	 * Check whether this soundfile is currently playing.
-	 * 
+	 *
 	 * @return `true` if the soundfile is currently playing, `false` if it is not.
-	 * @webref sound
+	 * @webref soundfile
+	 * @webBrief Check whether this soundfile is currently playing.
 	 */
 	public boolean isPlaying() {
 		return super.isPlaying();
@@ -272,14 +287,15 @@ public class SoundFile extends AudioSample {
 	 *            0.0 (complete silence) to 1.0 (full volume)
 	 * @param add
 	 *            offset the output of the generator by the given value
-	 * @webref sound
+	 * @webref soundfile
+	 * @webBrief Starts playback which will loop at the end of the soundfile.
 	 */
 	public void loop(float rate, float pos, float amp, float add) {
 		super.loop(rate, pos, amp, add);
 	}
 
 	/**
-	 * FIXME see comment in AudioSample class
+	 * Changes the amplitude/volume of the player. Allowed values are between 0.0 and 1.0.
 	 * 
 	 * @param cue
 	 *            position in the audiosample that the next playback or loop should
@@ -294,32 +310,37 @@ public class SoundFile extends AudioSample {
 	 * @param amp
 	 *            A float value between 0.0 (complete silence) and 1.0 (full volume)
 	 *            controlling the amplitude/volume of this sound.
-	 * @webref sound
+	 * @webref soundfile
+	 * @webBrief Changes the amplitude/volume of the player.
 	 **/
 	public void amp(float amp) {
 		super.amp(amp);
 	}
 
 	/**
-	 * Move the sound in a stereo panorama. Only works for mono soundfiles!
+	 * Move the sound in a stereo panorama.-1.0 pans to the left channel and 1.0 to the 
+	 * right channel. Note that panning is only supported for mono (1 channel) soundfiles.
 	 * 
 	 * @param pos
 	 *            the panoramic position of this sound unit from -1.0 (left) to 1.0
 	 *            (right).
-	 * @webref sound
+	 * @webref soundfile
+	 * @webBrief Move the sound in a stereo panorama.
 	 **/
 	public void pan(float pos) {
 		super.pan(pos);
 	}
 
 	/**
-	 * Set the playback rate of the soundfile.
+	 * Set the playback rate of the soundfile. 1 is the original speed. 0.5 is half speed 
+	 * and one octave down. 2 is double the speed and one octave up.
 	 * 
 	 * @param rate
 	 *            Relative playback rate to use. 1 is the original speed. 0.5 is
 	 *            half speed and one octave down. 2 is double the speed and one
 	 *            octave up.
-	 * @webref sound
+	 * @webref soundfile
+	 * @webBrief Set the playback rate of the soundfile.
 	 **/
 	public void rate(float rate) {
 		super.rate(rate);
@@ -329,7 +350,8 @@ public class SoundFile extends AudioSample {
 	 * Stops the playback.
 	 * 
 	 * @see pause
-	 * @webref sound
+	 * @webref soundfile
+	 * @webBrief Stops the playback.
 	 **/
 	public void stop() {
 		super.stop();

--- a/src/processing/sound/SoundObject.java
+++ b/src/processing/sound/SoundObject.java
@@ -35,7 +35,6 @@ public abstract class SoundObject {
 	/**
 	 * Offset the output of this generator by given value
 	 *
-	 * @webref sound
 	 * @param add
 	 *            A value for offsetting the audio signal.
 	 **/
@@ -53,7 +52,6 @@ public abstract class SoundObject {
 	 * @param amp
 	 *            A float value between 0.0 (complete silence) and 1.0 (full volume)
 	 *            controlling the amplitude/volume of this sound.
-	 * @webref sound
 	 **/
 	public void amp(float amp) {
 		if (Engine.checkAmp(amp)) {
@@ -67,7 +65,6 @@ public abstract class SoundObject {
 	/**
 	 * Check if this sound object is currently playing.
 	 *
-	 * @webref sound
 	 * @return `true` if this sound object is currently playing, `false` if it is
 	 *         not.
 	 */
@@ -78,7 +75,6 @@ public abstract class SoundObject {
 	/**
 	 * Move the sound in a stereo panorama.
 	 *
-	 * @webref sound
 	 * @param pos
 	 *            The panoramic position of this sound unit as a float from -1.0
 	 *            (left) to 1.0 (right).
@@ -94,7 +90,6 @@ public abstract class SoundObject {
 	/**
 	 * Start the generator
 	 *
-	 * @webref sound
 	 **/
 	public void play() {
 		// TODO print info message if it's already playing?
@@ -110,7 +105,6 @@ public abstract class SoundObject {
 	/**
 	 * Stop the generator
 	 *
-	 * @webref sound
 	 **/
 	public void stop() {
 		this.isPlaying = false;

--- a/src/processing/sound/SqrOsc.java
+++ b/src/processing/sound/SqrOsc.java
@@ -5,13 +5,13 @@ import com.jsyn.unitgen.SquareOscillator;
 import processing.core.PApplet;
 
 /**
- * This is a simple Square Wave Oscillator 
- * @webref sound
+ * This is a simple Square Wave Oscillator.
+ * @webref oscillators
+ * @webBrief This is a simple Square Wave Oscillator.
  **/
 public class SqrOsc extends Oscillator<SquareOscillator> {
 
 	/**
-	 * @webref sound
 	 * @param parent typically use "this"
 	 */
 	public SqrOsc(PApplet parent) {
@@ -34,20 +34,22 @@ public class SqrOsc extends Oscillator<SquareOscillator> {
 	}
 
 	/**
-	 * Starts the oscillator
+	 * Starts the oscillator.
 	 * @param freq The frequency value of the oscillator in Hz.
 	 * @param amp The amplitude of the oscillator as a value between 0.0 and 1.0.
 	 * @param add Offset the output of the oscillator by given value
 	 * @param pos The panoramic position of the oscillator as a float from -1.0 to 1.0.
-	 * @webref sound
+	 * @webref sqrosc
+	 * @webBrief Starts the oscillator.
 	 **/
 	public void play(float freq, float amp, float add, float pos) {
 		super.play(freq, amp, add, pos);
 	}
 
 	/**
-	 * Set multiple parameters at once
-	 * @webref sound
+	 * Set multiple parameters at once.
+	 * @webref sqrosc
+	 * @webBrief Set multiple parameters at once.
 	 * @param freq The frequency value of the oscillator in Hz.
 	 * @param amp The amplitude of the oscillator as a value between 0.0 and 1.0.
 	 * @param add Offset the output of the oscillator by given value
@@ -59,7 +61,8 @@ public class SqrOsc extends Oscillator<SquareOscillator> {
 	
 	/**
 	 * Set the frequency of the oscillator in Hz.
-	 * @webref sound
+	 * @webref sqrosc
+	 * @webBrief Set the frequency of the oscillator in Hz.
 	 * @param freq A floating point value of the oscillator in Hz.
 	 **/
 	public void freq(float freq) {
@@ -67,9 +70,11 @@ public class SqrOsc extends Oscillator<SquareOscillator> {
 	}
 
 	/**
-	 * Change the amplitude/volume of this sound.
+	 * Change the amplitude/volume of of the square oscillator. 
+	 * Allowed values are between 0.0 and 1.0.
 	 *
-	 * @webref sound
+	 * @webref sqrosc
+	 * @webBrief Change the amplitude/volume of of the square oscillator. 
 	 * @param amp
 	 *            A float value between 0.0 (complete silence) and 1.0 (full volume)
 	 *            controlling the amplitude/volume of this sound.
@@ -79,9 +84,10 @@ public class SqrOsc extends Oscillator<SquareOscillator> {
 	}
 
 	/**
-	 * Offset the output of this generator by given value
+	 * Offset the output of this generator by given value.
 	 *
-	 * @webref sound
+	 * @webref sqrosc
+	 * @webBrief Offset the output of this generator by given value.
 	 * @param add Offset the output of the oscillator by given value
 	 **/
 	public void add(float add) {
@@ -91,7 +97,8 @@ public class SqrOsc extends Oscillator<SquareOscillator> {
 	/**
 	 * Move the sound in a stereo panorama.
 	 *
-	 * @webref sound
+	 * @webref sqrosc
+	 * @webBrief Move the sound in a stereo panorama.
 	 * @param pos
 	 *            The panoramic position of this sound unit as a float from -1.0
 	 *            (left) to 1.0 (right).
@@ -103,7 +110,8 @@ public class SqrOsc extends Oscillator<SquareOscillator> {
 	/**
 	 * Stop the oscillator.
 	 *
-	 * @webref sound
+	 * @webref sqrosc
+	 * @webBrief Stop the oscillator.
 	 **/
 	public void stop() {
 		super.stop();

--- a/src/processing/sound/TriOsc.java
+++ b/src/processing/sound/TriOsc.java
@@ -5,13 +5,13 @@ import com.jsyn.unitgen.TriangleOscillator;
 import processing.core.PApplet;
 
 /**
- * This is a simple triangle (or "saw") wave oscillator
- * @webref sound
+ * This is a simple triangle (or "saw") wave oscillator.
+ * @webref oscillators
+ * @webBrief This is a simple triangle (or "saw") wave oscillator.
  **/
 public class TriOsc extends Oscillator<TriangleOscillator> {
 
 	/**
-	 * @webref sound
 	 * @param parent typically use "this"
 	 */
 	public TriOsc(PApplet parent) {
@@ -34,20 +34,22 @@ public class TriOsc extends Oscillator<TriangleOscillator> {
 	}
 
 	/**
-	 * Starts the oscillator
+	 * Starts the oscillator.
 	 * @param freq The frequency value of the oscillator in Hz.
 	 * @param amp The amplitude of the oscillator as a value between 0.0 and 1.0.
 	 * @param add Offset the output of the oscillator by given value
 	 * @param pos The panoramic position of the oscillator as a float from -1.0 to 1.0.
-	 * @webref sound
+	 * @webref triosc
+	 * @webBrief Starts the oscillator.
 	 **/
 	public void play(float freq, float amp, float add, float pos) {
 		super.play(freq, amp, add, pos);
 	}
 
 	/**
-	 * Set multiple parameters at once
-	 * @webref sound
+	 * Set multiple parameters at once.
+	 * @webref triosc
+	 * @webBrief Set multiple parameters at once.
 	 * @param freq The frequency value of the oscillator in Hz.
 	 * @param amp The amplitude of the oscillator as a value between 0.0 and 1.0.
 	 * @param add Offset the output of the oscillator by given value
@@ -59,7 +61,8 @@ public class TriOsc extends Oscillator<TriangleOscillator> {
 	
 	/**
 	 * Set the frequency of the oscillator in Hz.
-	 * @webref sound
+	 * @webref triosc
+	 * @webBrief Set the frequency of the oscillator in Hz.
 	 * @param freq A floating point value of the oscillator in Hz.
 	 **/
 	public void freq(float freq) {
@@ -67,9 +70,11 @@ public class TriOsc extends Oscillator<TriangleOscillator> {
 	}
 
 	/**
-	 * Change the amplitude/volume of this sound.
+	 * Changes the amplitude/volume of the triangle oscillator. 
+	 * Allowed values are between 0.0 and 1.0.
 	 *
-	 * @webref sound
+	 * @webref triosc
+	 * @webBrief Changes the amplitude/volume of the triangle oscillator. 
 	 * @param amp
 	 *            A float value between 0.0 (complete silence) and 1.0 (full volume)
 	 *            controlling the amplitude/volume of this sound.
@@ -79,9 +84,10 @@ public class TriOsc extends Oscillator<TriangleOscillator> {
 	}
 
 	/**
-	 * Offset the output of this generator by given value
+	 * Offset the output of this generator by given value.
 	 *
-	 * @webref sound
+	 * @webref triosc
+	 * @webBrief Offset the output of this generator by given value.
 	 * @param add Offset the output of the oscillator by given value
 	 **/
 	public void add(float add) {
@@ -89,9 +95,10 @@ public class TriOsc extends Oscillator<TriangleOscillator> {
 	}
 
 	/**
-	 * Move the sound in a stereo panorama.
+	 * Move the sound in a stereo panorama. -1.0 pans to the left channel and 1.0 to the right channel.
 	 *
-	 * @webref sound
+	 * @webref triosc
+	 * @webBrief Move the sound in a stereo panorama.
 	 * @param pos
 	 *            The panoramic position of this sound unit as a float from -1.0
 	 *            (left) to 1.0 (right).
@@ -103,7 +110,8 @@ public class TriOsc extends Oscillator<TriangleOscillator> {
 	/**
 	 * Stop the oscillator.
 	 *
-	 * @webref sound
+	 * @webref triosc
+	 * @webBrief Stop the oscillator.
 	 **/
 	public void stop() {
 		super.stop();

--- a/src/processing/sound/Waveform.java
+++ b/src/processing/sound/Waveform.java
@@ -8,12 +8,13 @@ import processing.core.PApplet;
 
 /**
  * This is a Waveform analyzer. It returns the waveform of the 
- * of an audio stream the moment it is queried with the analyze()
+ * of an audio stream the moment it is queried with the <b>analyze()</b>
  * method.
  * 
  * @author icalvin102
  * 
- * @webref sound
+ * @webref analysis
+ * @webBrief This is a Waveform analyzer.
  **/
 public class Waveform extends Analyzer {
 
@@ -28,7 +29,6 @@ public class Waveform extends Analyzer {
 	 *            typically use "this"
 	 * @param nsamples
 	 *            number of waveform samples that you want to be able to read at once (a positive integer).
-	 * @webref sound
 	 */
 	public Waveform(PApplet parent, int nsamples) {
 		super(parent);
@@ -76,7 +76,8 @@ public class Waveform extends Analyzer {
 	 *            samples
 	 * @return the current audiobuffer of the input source. The array has as
 	 *         many elements as this Waveform analyzer's number of samples
-	 * @webref sound
+	 * @webref waveform
+	 * @webBrief Gets the content of the current audiobuffer from the input source.
 	 **/
 	public float[] analyze(float[] value) {
 		if (this.input == null) {
@@ -121,7 +122,8 @@ public class Waveform extends Analyzer {
 	 * @param input
 	 *            the input sound source. Can be an oscillator, noise generator,
 	 *            SoundFile or AudioIn.
-	 * @webref sound
+	 * @webref waveform
+	 * @webBrief Define the audio input for the analyzer.
 	 **/
 	public void input(SoundObject input) {
 		super.input(input);

--- a/src/processing/sound/WhiteNoise.java
+++ b/src/processing/sound/WhiteNoise.java
@@ -4,13 +4,13 @@ import processing.core.PApplet;
 
 /**
  * This is a White Noise Generator. White Noise has a flat spectrum. 
- * @webref sound
+ * @webref noise
+ * @webBrief This is a White Noise Generator.
  **/
 public class WhiteNoise extends Noise<com.jsyn.unitgen.WhiteNoise> {
 
 	/**
 	 * @param parent typically use "this"	
-	 * @webref sound
 	 */
 	public WhiteNoise(PApplet parent) {
 		super(parent, new com.jsyn.unitgen.WhiteNoise());
@@ -33,11 +33,12 @@ public class WhiteNoise extends Noise<com.jsyn.unitgen.WhiteNoise> {
 	}
 
 	/**
-	 * Start the generator
+	 * Start the generator.
 	 * @param amp the amplitude of the noise as a value from 0.0 (complete silence) to 1.0 (full volume)
 	 * @param add offset the output of the noise by given value
 	 * @param pos pan the generator in stereo panorama. Allowed values are between -1.0 and 1.0.
-	 * @webref sound
+	 * @webref whitenoise
+	 * @webBrief Start the generator.
 	 **/
 	public void play(float amp, float add, float pos) {
 		super.play(amp, add, pos);
@@ -48,16 +49,18 @@ public class WhiteNoise extends Noise<com.jsyn.unitgen.WhiteNoise> {
 	 * @param amp the amplitude of the noise as a value from 0.0 (complete silence) to 1.0 (full volume)
 	 * @param add offset the output of the noise by given value
 	 * @param pos pan the generator in stereo panorama. Allowed values are between -1.0 and 1.0.
-	 * @webref sound
+	 * @webref whitenoise
+	 * @webBrief Set multiple parameters at once.
 	 **/
 	public void set(float amp, float add, float pos) {
 		super.set(amp, add, pos);
 	}
 
 	/**
-	 * Change the amplitude/volume of this sound.
+	 * Change the amplitude/volume of this sound. Allowed values are between 0.0 and 1.0.
 	 * @param amp the amplitude of the noise as a value from 0.0 (complete silence) to 1.0 (full volume)
-	 * @webref sound
+	 * @webref whitenoise
+	 * @webBrief Change the amplitude/volume of this sound.
 	 **/
 	public void amp(float amp) {
 		// the JSyn Brownian noise generator can drift to exceed one, so tone down the volume a bit
@@ -65,28 +68,31 @@ public class WhiteNoise extends Noise<com.jsyn.unitgen.WhiteNoise> {
 	}
 
 	/**
-	 * Offset the output of this generator by a fixed value
+	 * Offset the output of this generator by a fixed value.
 	 * @param add offset the output of the generator by the given value
-	 * @webref sound
+	 * @webref whitenoise
+	 * @webBrief Offset the output of this generator by a fixed value.
 	 **/
 	public void add(float add) {
 		super.add(add);
 	}
 
 	/**
-	 * Move the sound in a stereo panorama.
+	 * Move the sound in a stereo panorama. -1.0 pans to the left channel and 1.0 to the right channel.
 	 * @param pos
 	 *            the panoramic position of this sound unit from -1.0 (left) to 1.0
 	 *            (right).
-	 * @webref sound
+	 * @webref whitenoise
+	 * @webBrief Move the sound in a stereo panorama.
 	 **/
 	public void pan(float pos) {
 		super.pan(pos);
 	}
 
 	/**
-	 * Stop the generator
-	 * @webref sound
+	 * Stop the generator.
+	 * @webref whitenoise
+	 * @webBrief Stop the generator.
 	 **/
 	public void stop() {
 		super.stop();


### PR DESCRIPTION
This PR adjusts the comments in the java files to fit with the new reference system created for the new processing website. You can see details for the new reference system [here](https://github.com/processing/processing-website/blob/master/docs/reference.md#adding-content-to-the-english-reference). 

Changes are made to all the comments that have `@webref` in them. Since the sound library classes rely on some inherited methods and this methods should appear on the sound reference page on the processing website, we have created individual `.json` files to make it possible. These files are directly made in the [website repo](https://github.com/processing/processing-website/tree/master/content/references/translations/en/sound) for example `AudioIn_add_.json`, `AudioIn_amp_.json`, `AudioIn_pan_.json` etc. The content for these files corresponds to the old `.xml` files found [here](https://github.com/processing/processing-docs/tree/master/content/api_en/LIB_sound) and detailed `.java` references [here](https://processing.github.io/processing-sound/processing/sound/package-summary.html).

Let me know if you have any questions! 