### PR TITLE
Fixed comments for saw wave oscillator documentation

### DIFF
--- a/examples/Oscillators/SawWave/SawWave.pde
+++ b/examples/Oscillators/SawWave/SawWave.pde
@@ -13,7 +13,7 @@ void setup() {
   size(640, 360);
   background(255);
 
-  // Create and start the saw oscillator.
+  // Create and start the sawtooth wave oscillator.
   saw = new SawOsc(this);
   saw.play();
 }


### PR DESCRIPTION
Issue: https://github.com/processing/processing-website/issues/372

Previously, the comment line stated that the following two lines of code created and started the 'saw oscillator'. The phrase has been fixed to read 'sawtooth wave oscillator'.

Signed-off-by: Arya Gupta <arya.gupta99999@gmail.com>