### PR TITLE
Add a function to calculate the fft of a given sample array. 

### DIFF
--- a/src/processing/sound/FFT.java
+++ b/src/processing/sound/FFT.java
@@ -84,6 +84,31 @@ public class FFT extends Analyzer {
 		return value;
 	}
 
+	/**
+	 * Calculates the frequency spectrum of the given sample and returns an array of magnitudes, one
+	 * for each frequency band.
+	 *
+	 * This version is intended to be used in non-real time processing, particularly when you are
+	 * creating an animation in non-real time and want to get the FFT for a particular chunk of an audio sample.
+	 *
+	 * For stereo samples, you can call this function once for each channel, so you can display the left and right
+	 * fft values separately.
+	 *
+	 * @param sample
+	 *            an array with sound samples
+	 * @param numBands
+	 *            the number of fft bands requested. Must be a power of 2 (one of 2, 4, 8, 16 etc.)
+	 * @return The current frequency spectrum of the input source. The array has as
+	 *         many elements as this FFT analyzer's number of frequency bands.
+	 * @webref fft
+	 * @webBrief Calculates the frequency spectrum of the given sample, returning an array of magnitudes.
+	 **/
+	public float[] analyzeSample(float[] sample, int numBands) {
+		float[] target = new float[numBands];
+		fft.calculateMagnitudesFromSample(sample, target);
+		return target;
+	}
+
 	// Below are just duplicated methods from superclasses which are required
 	// for the online reference to build the corresponding pages.
 

--- a/src/processing/sound/JSynFFT.java
+++ b/src/processing/sound/JSynFFT.java
@@ -39,8 +39,28 @@ class JSynFFT extends FixedRateMonoWriter {
 		Arrays.fill(this.imaginary, 0);
 		FourierMath.fft(this.real.length, this.real, this.imaginary);
 		FourierMath.calculateMagnitudes(this.real, this.imaginary, this.magnitude);
+
 		for (int i = 0; i < target.length; i++) {
 			target[i] = (float) (2 * this.magnitude[i]);
+		}
+	}
+
+	protected void calculateMagnitudesFromSample(float[] sample, float[] target) {
+
+		double[] real = new double[sample.length];
+		double[] imaginary = new double[sample.length];
+		double[] magnitude = new double[target.length];
+		Arrays.fill(imaginary, 0);
+
+		for (int i = 0; i < sample.length; i++) {
+			real[i] = sample[i];
+		}
+
+		FourierMath.fft(target.length, real, imaginary);
+		FourierMath.calculateMagnitudes(real, imaginary, magnitude);
+
+		for (int i = 0; i < target.length; i++) {
+			target[i] = (float) magnitude[i];
 		}
 	}
 }


### PR DESCRIPTION
This addresses #77. When using processing to generate images to stitch into an animation, the present fft function presents timing issues.

This addresses those by allowing the client to pass in a portion of their AudioSample for fft processing, so that one can process the correct part of the audio for each video frame.

Here is an example of how to use it inside a draw() function, assuming a mono source:
```
int startSample = frameNo * samplesPerFrame;
float[] sampleForThisFrame = new float[samplesPerFrame];
soundFile.read(startSample, sampleForThisFrame, 0, samplesPerFrame);
float[] fftMagnitudes = fft.analyzeSample(sampleForThisFrame, 64);
```
For stereo, one could extract the left and right channels from the soundFile and process them with fft separately.

