### PR TITLE
Correct reference to wrong input array length

### DIFF
--- a/src/processing/sound/FFT.java
+++ b/src/processing/sound/FFT.java
@@ -136,7 +136,7 @@ public class FFT extends Analyzer {
 	// the meat of the matter
 	protected static void calculateMagnitudesFromSample(float[] sample, float[] imaginary, float[] target) {
 		if (FFT.checkNumBands(target.length)) {
-			FourierMath.transform(1, sample.length, sample, imaginary);
+			FourierMath.transform(1, target.length, sample, imaginary);
 			FourierMath.calculateMagnitudes(sample, imaginary, target);
 			// there is an argument for multiplying the normalized spectrum amplitude 
 			// values by two, see e.g.:


### PR DESCRIPTION
Leads to an assertion error when the input audio length is not also a power of 2. See issue #104.